### PR TITLE
Refine metadata setup and PCA handling

### DIFF
--- a/R/pca.R
+++ b/R/pca.R
@@ -259,6 +259,7 @@ plot_all_biplots <- function(
     fig_width = 8.4,
     fig_height = 7.6,
     save_func = NULL,
+    rankname_order = NULL,
     ...) {
   log_msg(debug=paste0('colby equal to : ', colby))
   pca_objects %>%
@@ -267,6 +268,14 @@ plot_all_biplots <- function(
         pca_object <- .x
         title <- .y
         collection_name <- .y
+        if (!is.null(rankname_order) &&
+            !is.null(pca_object$metadata) &&
+            all(rankname_order %in% rownames(pca_object$metadata))) {
+          pca_object$metadata <- pca_object$metadata[rankname_order, , drop = FALSE]
+          if (!is.null(pca_object$rotated)) {
+            pca_object$rotated <- pca_object$rotated[rankname_order, , drop = FALSE]
+          }
+        }
 
         plts <- colby %>% purrr::map(
             ~{
@@ -379,6 +388,7 @@ make_heatmap_from_loadings <- function(
     cut_by = NULL,
     cluster_rows = TRUE,
     cluster_columns = FALSE,
+    rankname_order = NULL,
     meta_to_include = NULL,
     meta_to_exclude = NULL,
     ...){
@@ -440,6 +450,9 @@ make_heatmap_from_loadings <- function(
         cluster_rows = cluster_rows,
         cluster_columns = cluster_columns,
         cut_by = .cut_by,
+        rankname_order = rankname_order,
+        meta_to_include = meta_to_include,
+        meta_to_exclude = meta_to_exclude,
         save_func = .save_func,
       )}, error = function(msg) { log_msg(error=msg) }
     ) # end of tryCatch

--- a/R/tests/unit_tests/test_run.R
+++ b/R/tests/unit_tests/test_run.R
@@ -233,3 +233,22 @@ testthat::test_that("test main function with valid parameters", {
 # )
 
 # test_render()
+
+
+# tests for prepare_metadata
+testthat::test_that("prepare_metadata returns NULL when gct missing", {
+  params <- list(ranks_from = "gct", extra = list(rankname_order = c("B","A")))
+  expect_null(run_env$prepare_metadata(NULL, params))
+})
+
+testthat::test_that("prepare_metadata orders group correctly", {
+  mat <- matrix(1:4, nrow = 2)
+  colnames(mat) <- c("s1","s2")
+  rdesc <- data.frame(id = rownames(mat))
+  rownames(rdesc) <- rownames(mat)
+  cdesc <- data.frame(group = c("A","B"), row.names = c("s1","s2"))
+  gct <- new("GCT", mat = mat, cdesc = cdesc, rdesc = rdesc)
+  params <- list(ranks_from = "gct", extra = list(rankname_order = c("B","A")))
+  meta <- run_env$prepare_metadata(gct, params)
+  testthat::expect_equal(rownames(meta), c("s2","s1"))
+})


### PR DESCRIPTION
## Summary
- Add `prepare_metadata` helper to load and validate metadata before running analyses
- Guard PCA steps with metadata checks and propagate `rankname_order`
- Correct heatmap parameters and argument wiring

## Testing
- `bash test.sh` *(fails: Rscript: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b459bbd0833296f4ddd66da34a65