### PR TITLE
Unify AGI engine context management

### DIFF
--- a/python/tests/test_context_engine.py
+++ b/python/tests/test_context_engine.py
@@ -1,0 +1,133 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from agi.engine import (
+    ContextGraph,
+    ContextPack,
+    ContextRegistry,
+    ContextView,
+    RollingSummary,
+    SummaryEngine,
+)
+
+
+def test_registry_add_update_and_prune():
+    registry = ContextRegistry()
+    first = registry.add_item(" first message  ", score=0.1, metadata={"source": "alpha"}, tags=["tag", "tag"])
+    second = registry.add_item("second message", score=0.3)
+
+    updated_first = registry.update_item(first.id, score=0.5, metadata={"priority": "high"}, tags=["tag", "new"])
+    assert updated_first.score == 0.5
+    assert updated_first.metadata["source"] == "alpha"
+    assert updated_first.metadata["priority"] == "high"
+    assert updated_first.tags == ("tag", "new")
+
+    registry.prune(max_items=1)
+    assert len(registry) == 1
+    assert second.id in registry
+    assert first.id not in registry
+
+
+def test_registry_combine_returns_mapping():
+    base = ContextRegistry()
+    existing = base.add_item("existing", item_id="ctx-1")
+
+    other = ContextRegistry()
+    duplicate = other.add_item("duplicate", item_id=existing.id)
+
+    mapping = base.combine(other)
+    assert len(base) == 2
+    assert duplicate.id in mapping
+    assert mapping[duplicate.id] != duplicate.id
+
+
+def test_context_graph_relationships():
+    graph = ContextGraph()
+    root = graph.add_item("root event")
+    child = graph.add_item("child", parent_ids=[root.id])
+    grandchild = graph.add_item("grandchild", parent_ids=[child.id])
+
+    assert graph.parents(child.id) == (root.id,)
+    assert graph.children(root.id) == (child.id,)
+    assert set(graph.descendants(root.id)) == {child.id, grandchild.id}
+
+    walked = [item.id for item in graph.walk(root.id)]
+    assert walked == [root.id, child.id, grandchild.id]
+
+    sub = graph.subgraph(root.id)
+    assert isinstance(sub, ContextGraph)
+    assert set(item.id for item in sub.iter_items()) == {root.id, child.id, grandchild.id}
+
+
+def test_context_pack_grouping_and_combine():
+    pack_registry = ContextPack()
+    first = pack_registry.add_item("alpha entry", score=0.1)
+    second = pack_registry.add_item("bravo entry", score=0.9)
+    pack = pack_registry.create_pack([first.id, second.id], label="session", metadata={"kind": "demo"})
+
+    pack_registry.extend_pack(pack.id, [first.id])
+    assert pack_registry.get_pack(pack.id).item_ids == (first.id, second.id)
+
+    other = ContextPack()
+    other_item = other.add_item("charlie", item_id=first.id)
+    other_pack = other.create_pack([other_item.id], pack_id="pack-1")
+
+    pack_registry.combine(other)
+    combined_packs = list(pack_registry.iter_packs())
+    assert len(combined_packs) == 2
+    combined_ids = {p.id for p in combined_packs}
+    assert pack.id in combined_ids
+    assert any(pack_registry[p.item_ids[0]].text == "charlie" for p in combined_packs if other_pack.id != p.id)
+
+
+def test_summary_engine_behaviour():
+    registry = ContextRegistry()
+    low = registry.add_item("low priority", score=0.1)
+    high = registry.add_item("critical update", score=0.9)
+
+    engine = SummaryEngine(registry)
+    summary = engine.summarize_items(max_items=1)
+    assert "critical update" in summary
+
+    view = ContextView(item_ids=(low.id, high.id), label="both")
+    view_summary = engine.summarize_view(view, max_items=2)
+    assert "low priority" in view_summary
+
+    pack_registry = ContextPack(items=registry.get_recent(2))
+    pack = pack_registry.create_pack([low.id, high.id])
+    pack_summary = engine.summarize_pack(pack)
+    assert "critical update" in pack_summary
+
+    graph = ContextGraph(items=registry.get_recent(2))
+    graph.add_edge(low.id, high.id)
+    graph_summary = engine.summarize_graph(graph, low.id)
+    assert "low priority" in graph_summary
+
+
+def test_rolling_summary_tracks_recent_items():
+    registry = ContextRegistry()
+    first = registry.add_item("Message A")
+    second = registry.add_item("Message B")
+    third = registry.add_item("Message C")
+
+    engine = SummaryEngine(registry)
+    rolling = RollingSummary(engine, history_size=2, max_items=2, max_chars=120)
+
+    rolling.push(first.id)
+    assert "Message A" in rolling.summary
+
+    rolling.push(second.id)
+    assert "Message B" in rolling.summary
+
+    rolling.push(third.id)
+    assert "Message C" in rolling.summary
+    assert "Message A" not in rolling.summary
+
+    rolling.extend([first.id, second.id])
+    assert "Message B" in rolling.summary
+    assert "Message C" not in rolling.summary

--- a/src/agi/__init__.py
+++ b/src/agi/__init__.py
@@ -1,0 +1,5 @@
+"""AGI utilities package."""
+
+from . import engine
+
+__all__ = ["engine"]

--- a/src/agi/engine/__init__.py
+++ b/src/agi/engine/__init__.py
@@ -1,0 +1,23 @@
+"""Unifies context management utilities for the AGI engine.
+
+This module exposes a cohesive API that was previously spread across
+``context_graph``, ``context_pack`` and ``summarizer``.  The
+implementation now revolves around :class:`~agi.engine.context_base.ContextRegistry`
+which provides the shared data model for all high-level helpers.
+"""
+
+from .context_base import ContextItem, ContextRegistry, ContextView
+from .context_graph import ContextGraph
+from .context_pack import ContextPack, Pack
+from .summarizer import SummaryEngine, RollingSummary
+
+__all__ = [
+    "ContextItem",
+    "ContextRegistry",
+    "ContextView",
+    "ContextGraph",
+    "ContextPack",
+    "Pack",
+    "SummaryEngine",
+    "RollingSummary",
+]

--- a/src/agi/engine/context_base.py
+++ b/src/agi/engine/context_base.py
@@ -1,0 +1,294 @@
+"""Core data structures used across the AGI engine context utilities.
+
+Historically the context graph, packing utilities and summariser all kept
+slightly different versions of the same bookkeeping logic.  The classes
+below consolidate that shared behaviour so higher level modules can focus
+on their specific tasks (graph relationships, logical packing or
+summarisation).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace, field
+from datetime import datetime, timezone
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Mapping, Optional, Sequence, Tuple
+from types import MappingProxyType
+
+__all__ = ["ContextItem", "ContextRegistry", "ContextView"]
+
+
+def _freeze_mapping(value: Optional[Mapping[str, Any]]) -> Mapping[str, Any]:
+    """Return an immutable mapping, normalising ``None`` to an empty dict."""
+
+    if value is None:
+        return MappingProxyType({})
+    if isinstance(value, MappingProxyType):
+        return value
+    return MappingProxyType(dict(value))
+
+
+def _normalise_tags(tags: Optional[Sequence[str]]) -> Tuple[str, ...]:
+    if not tags:
+        return tuple()
+    return tuple(dict.fromkeys(tag.strip() for tag in tags if tag and tag.strip()))
+
+
+def _normalise_parents(parent_ids: Optional[Sequence[str]]) -> Tuple[str, ...]:
+    if not parent_ids:
+        return tuple()
+    return tuple(dict.fromkeys(pid for pid in parent_ids if pid))
+
+
+def _clean_text(text: str) -> str:
+    return " ".join(text.split())
+
+
+@dataclass(frozen=True)
+class ContextItem:
+    """A single unit of contextual information."""
+
+    id: str
+    text: str
+    score: float = 0.0
+    metadata: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+    tags: Tuple[str, ...] = field(default_factory=tuple)
+    parent_ids: Tuple[str, ...] = field(default_factory=tuple)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def clone(
+        self,
+        *,
+        id: Optional[str] = None,
+        text: Optional[str] = None,
+        score: Optional[float] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+        tags: Optional[Sequence[str]] = None,
+        parent_ids: Optional[Sequence[str]] = None,
+        created_at: Optional[datetime] = None,
+    ) -> "ContextItem":
+        """Return a copy with any provided fields updated."""
+
+        updates: Dict[str, Any] = {}
+        if id is not None:
+            updates["id"] = id
+        if text is not None:
+            updates["text"] = _clean_text(text)
+        if score is not None:
+            updates["score"] = score
+        if metadata is not None:
+            updates["metadata"] = _freeze_mapping(metadata)
+        if tags is not None:
+            updates["tags"] = _normalise_tags(tags)
+        if parent_ids is not None:
+            updates["parent_ids"] = _normalise_parents(parent_ids)
+        if created_at is not None:
+            updates["created_at"] = created_at
+        return replace(self, **updates)
+
+    def merged_metadata(self, extra: Mapping[str, Any]) -> "ContextItem":
+        """Return a copy with ``extra`` merged into the metadata."""
+
+        new_metadata: Dict[str, Any] = dict(self.metadata)
+        new_metadata.update(extra)
+        return self.clone(metadata=new_metadata)
+
+
+@dataclass(frozen=True)
+class ContextView:
+    """A lightweight handle describing a subset of context items."""
+
+    item_ids: Tuple[str, ...]
+    label: Optional[str] = None
+    metadata: Mapping[str, Any] = field(default_factory=lambda: MappingProxyType({}))
+
+    def items(self, registry: "ContextRegistry") -> Iterator[ContextItem]:
+        for item_id in self.item_ids:
+            yield registry[item_id]
+
+
+class ContextRegistry:
+    """Central store for :class:`ContextItem` instances.
+
+    The registry provides consistent lifecycle management (creation,
+    updates, pruning and serialisation) which is reused by the graph,
+    packing and summarisation helpers.  Callers can subclass it to bolt on
+    additional behaviour without re-implementing the persistence layer.
+    """
+
+    def __init__(self, *, id_prefix: str = "ctx", items: Optional[Iterable[ContextItem]] = None) -> None:
+        self._id_prefix = id_prefix
+        self._next_index: int = 1
+        self._items: Dict[str, ContextItem] = {}
+        self._order: List[str] = []
+        if items:
+            for item in items:
+                self._register_item(item)
+
+    # ------------------------------------------------------------------
+    # basic container protocol helpers
+    def __contains__(self, item_id: object) -> bool:  # pragma: no cover - trivial
+        return isinstance(item_id, str) and item_id in self._items
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return len(self._items)
+
+    def __iter__(self) -> Iterator[ContextItem]:  # pragma: no cover - convenience
+        return self.iter_items()
+
+    def __getitem__(self, item_id: str) -> ContextItem:
+        return self._items[item_id]
+
+    # ------------------------------------------------------------------
+    def _generate_id(self) -> str:
+        generated = f"{self._id_prefix}-{self._next_index}"
+        self._next_index += 1
+        return generated
+
+    def _adjust_index(self, item_id: str) -> None:
+        prefix = f"{self._id_prefix}-"
+        if item_id.startswith(prefix):
+            suffix = item_id[len(prefix) :]
+            if suffix.isdigit():
+                self._next_index = max(self._next_index, int(suffix) + 1)
+
+    def _register_item(self, item: ContextItem) -> None:
+        self._items[item.id] = item
+        self._order.append(item.id)
+        self._adjust_index(item.id)
+
+    # ------------------------------------------------------------------
+    def add_item(
+        self,
+        text: str,
+        *,
+        score: float = 0.0,
+        metadata: Optional[Mapping[str, Any]] = None,
+        tags: Optional[Sequence[str]] = None,
+        parent_ids: Optional[Sequence[str]] = None,
+        item_id: Optional[str] = None,
+        created_at: Optional[datetime] = None,
+    ) -> ContextItem:
+        """Create and store a new :class:`ContextItem`."""
+
+        if item_id is None:
+            item_id = self._generate_id()
+        elif item_id in self._items:
+            raise ValueError(f"Context item '{item_id}' already exists")
+
+        item = ContextItem(
+            id=item_id,
+            text=_clean_text(text),
+            score=score,
+            metadata=_freeze_mapping(metadata),
+            tags=_normalise_tags(tags),
+            parent_ids=_normalise_parents(parent_ids),
+            created_at=created_at or datetime.now(timezone.utc),
+        )
+        self._register_item(item)
+        return item
+
+    def update_item(
+        self,
+        item_id: str,
+        *,
+        text: Optional[str] = None,
+        score: Optional[float] = None,
+        metadata: Optional[Mapping[str, Any]] = None,
+        tags: Optional[Sequence[str]] = None,
+        parent_ids: Optional[Sequence[str]] = None,
+    ) -> ContextItem:
+        """Update an existing context item, returning the new version."""
+
+        item = self._items[item_id]
+        updates: Dict[str, Any] = {}
+        if text is not None:
+            updates["text"] = _clean_text(text)
+        if score is not None:
+            updates["score"] = score
+        if metadata is not None:
+            merged = dict(item.metadata)
+            merged.update(metadata)
+            updates["metadata"] = _freeze_mapping(merged)
+        if tags is not None:
+            updates["tags"] = _normalise_tags(tags)
+        if parent_ids is not None:
+            updates["parent_ids"] = _normalise_parents(parent_ids)
+        updated = replace(item, **updates)
+        self._items[item_id] = updated
+        return updated
+
+    def merge_metadata(self, item_id: str, extra: Mapping[str, Any]) -> ContextItem:
+        updated = self._items[item_id].merged_metadata(extra)
+        self._items[item_id] = updated
+        return updated
+
+    def iter_items(self, *, reverse: bool = False) -> Iterator[ContextItem]:
+        order = reversed(self._order) if reverse else self._order
+        for item_id in order:
+            yield self._items[item_id]
+
+    def get_recent(self, count: int) -> List[ContextItem]:
+        return list(self.iter_items(reverse=True))[:count]
+
+    def filter_items(self, predicate: Callable[[ContextItem], bool]) -> Iterator[ContextItem]:
+        for item in self.iter_items():
+            if predicate(item):
+                yield item
+
+    def remove_item(self, item_id: str) -> ContextItem:
+        removed = self._items.pop(item_id)
+        self._order.remove(item_id)
+        return removed
+
+    def prune(self, *, max_items: int) -> None:
+        """Drop the oldest items until ``max_items`` remain."""
+
+        if max_items < 0:
+            raise ValueError("max_items must be non-negative")
+        while len(self._order) > max_items:
+            oldest_id = self._order.pop(0)
+            self._items.pop(oldest_id, None)
+
+    # ------------------------------------------------------------------
+    def combine(self, other: "ContextRegistry") -> Dict[str, str]:
+        """Merge another registry into this one.
+
+        Returns a mapping of ``other``'s ids to the ids that ended up in the
+        combined registry which allows subclasses to remap secondary
+        structures (e.g. graph edges or pack membership).
+        """
+
+        id_map: Dict[str, str] = {}
+        for item in other.iter_items():
+            new_id = item.id
+            if new_id in self._items:
+                new_id = self._generate_id()
+            self._register_item(item.clone(id=new_id))
+            id_map[item.id] = new_id
+        return id_map
+
+    def to_snapshot(self) -> Dict[str, Any]:
+        """Return a serialisable representation of the registry."""
+
+        return {
+            "items": [
+                {
+                    "id": item.id,
+                    "text": item.text,
+                    "score": item.score,
+                    "metadata": dict(item.metadata),
+                    "tags": list(item.tags),
+                    "parent_ids": list(item.parent_ids),
+                    "created_at": item.created_at.isoformat(),
+                }
+                for item in self.iter_items()
+            ]
+        }
+
+    # ------------------------------------------------------------------
+    def copy(self) -> "ContextRegistry":
+        """Return a shallow copy preserving insertion order."""
+
+        return ContextRegistry(id_prefix=self._id_prefix, items=list(self.iter_items()))
+
+

--- a/src/agi/engine/context_graph.py
+++ b/src/agi/engine/context_graph.py
@@ -1,0 +1,175 @@
+"""Graph utilities for contextual information."""
+
+from __future__ import annotations
+
+from collections import deque, defaultdict
+from typing import Dict, Iterable, Iterator, Optional, Sequence, Set, Tuple
+
+from .context_base import ContextItem, ContextRegistry
+
+__all__ = ["ContextGraph"]
+
+
+class ContextGraph(ContextRegistry):
+    """Context registry with parent/child relationships between items."""
+
+    def __init__(
+        self,
+        *,
+        id_prefix: str = "ctx",
+        items: Optional[Iterable[ContextItem]] = None,
+        edges: Optional[Iterable[Tuple[str, str]]] = None,
+    ) -> None:
+        super().__init__(id_prefix=id_prefix, items=items)
+        self._children: Dict[str, Set[str]] = defaultdict(set)
+        self._parents: Dict[str, Set[str]] = defaultdict(set)
+        if edges:
+            for parent_id, child_id in edges:
+                if parent_id not in self or child_id not in self:
+                    raise KeyError(f"Edge references unknown item: {parent_id!r}->{child_id!r}")
+                self._children[parent_id].add(child_id)
+                self._parents[child_id].add(parent_id)
+
+    # ------------------------------------------------------------------
+    def add_edge(self, parent_id: str, child_id: str) -> None:
+        """Link two existing context items."""
+
+        if parent_id not in self:
+            raise KeyError(f"Unknown parent '{parent_id}'")
+        if child_id not in self:
+            raise KeyError(f"Unknown child '{child_id}'")
+        if child_id in self._children[parent_id]:
+            return
+        self._children[parent_id].add(child_id)
+        self._parents[child_id].add(parent_id)
+        child = self[child_id]
+        parent_ids = tuple(dict.fromkeys((*child.parent_ids, parent_id)))
+        super().update_item(child_id, parent_ids=parent_ids)
+
+    def remove_edge(self, parent_id: str, child_id: str) -> None:
+        if child_id in self._children.get(parent_id, set()):
+            self._children[parent_id].remove(child_id)
+            if not self._children[parent_id]:
+                self._children.pop(parent_id, None)
+            parents = set(self._parents.get(child_id, set()))
+            parents.discard(parent_id)
+            if parents:
+                self._parents[child_id] = parents
+            else:
+                self._parents.pop(child_id, None)
+            super().update_item(child_id, parent_ids=tuple(sorted(parents)))
+
+    def add_item(
+        self,
+        text: str,
+        *,
+        parent_ids: Optional[Sequence[str]] = None,
+        **kwargs,
+    ) -> ContextItem:
+        item = super().add_item(text, parent_ids=parent_ids, **kwargs)
+        for parent_id in item.parent_ids:
+            self.add_edge(parent_id, item.id)
+        return item
+
+    def remove_item(self, item_id: str) -> ContextItem:
+        for parent_id in list(self._parents.get(item_id, set())):
+            self.remove_edge(parent_id, item_id)
+        for child_id in list(self._children.get(item_id, set())):
+            self.remove_edge(item_id, child_id)
+        return super().remove_item(item_id)
+
+    # ------------------------------------------------------------------
+    def parents(self, item_id: str) -> Tuple[str, ...]:
+        return tuple(sorted(self._parents.get(item_id, set())))
+
+    def children(self, item_id: str) -> Tuple[str, ...]:
+        return tuple(sorted(self._children.get(item_id, set())))
+
+    def ancestors(self, item_id: str) -> Tuple[str, ...]:
+        seen: Set[str] = set()
+        queue: deque[str] = deque(self._parents.get(item_id, set()))
+        while queue:
+            current = queue.popleft()
+            if current in seen:
+                continue
+            seen.add(current)
+            queue.extend(self._parents.get(current, set()))
+        return tuple(sorted(seen))
+
+    def descendants(self, item_id: str) -> Tuple[str, ...]:
+        seen: Set[str] = set()
+        queue: deque[str] = deque(self._children.get(item_id, set()))
+        while queue:
+            current = queue.popleft()
+            if current in seen:
+                continue
+            seen.add(current)
+            queue.extend(self._children.get(current, set()))
+        return tuple(sorted(seen))
+
+    def walk(
+        self,
+        start_id: str,
+        *,
+        direction: str = "forward",
+        depth: Optional[int] = None,
+        include_start: bool = True,
+    ) -> Iterator[ContextItem]:
+        """Yield items reachable from ``start_id`` using breadth-first search."""
+
+        if start_id not in self:
+            raise KeyError(f"Unknown item '{start_id}'")
+        if direction not in {"forward", "backward", "both"}:
+            raise ValueError("direction must be 'forward', 'backward' or 'both'")
+
+        visited: Set[str] = set()
+        queue: deque[Tuple[str, int]] = deque([(start_id, 0)])
+        while queue:
+            current, current_depth = queue.popleft()
+            if current in visited:
+                continue
+            visited.add(current)
+            if current != start_id or include_start:
+                yield self[current]
+            if depth is not None and current_depth >= depth:
+                continue
+            next_depth = current_depth + 1
+            if direction in {"forward", "both"}:
+                for child in self._children.get(current, set()):
+                    queue.append((child, next_depth))
+            if direction in {"backward", "both"}:
+                for parent in self._parents.get(current, set()):
+                    queue.append((parent, next_depth))
+
+    def subgraph(self, root_id: str, *, depth: Optional[int] = None) -> "ContextGraph":
+        """Return a new :class:`ContextGraph` limited to ``root_id``'s neighbourhood."""
+
+        items = {root_id}
+        edges: Set[Tuple[str, str]] = set()
+        for node in self.walk(root_id, depth=depth):
+            items.add(node.id)
+        for parent_id in list(items):
+            for child_id in self._children.get(parent_id, set()):
+                if child_id in items:
+                    edges.add((parent_id, child_id))
+        return ContextGraph(
+            id_prefix=self._id_prefix,
+            items=[self[item_id] for item_id in items],
+            edges=edges,
+        )
+
+    # ------------------------------------------------------------------
+    def combine(self, other: ContextRegistry) -> None:
+        """Extend :meth:`ContextRegistry.combine` to include edges."""
+
+        if not isinstance(other, ContextGraph):
+            super().combine(other)
+            return
+        id_map = super().combine(other)
+        for parent_id, children in other._children.items():
+            new_parent = id_map.get(parent_id, parent_id)
+            for child_id in children:
+                new_child = id_map.get(child_id, child_id)
+                if new_parent in self and new_child in self:
+                    self.add_edge(new_parent, new_child)
+

--- a/src/agi/engine/context_pack.py
+++ b/src/agi/engine/context_pack.py
@@ -1,0 +1,158 @@
+"""Context packing utilities built on the shared :mod:`agi.engine` core."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace, field
+from typing import Dict, Iterable, Iterator, Mapping, Optional, Sequence, Tuple
+from types import MappingProxyType
+
+from .context_base import ContextItem, ContextRegistry
+
+__all__ = ["ContextPack", "Pack"]
+
+
+def _freeze_metadata(metadata: Optional[Mapping[str, object]]) -> Mapping[str, object]:
+    if metadata is None:
+        return MappingProxyType({})
+    if isinstance(metadata, MappingProxyType):
+        return metadata
+    return MappingProxyType(dict(metadata))
+
+
+def _normalise_ids(item_ids: Sequence[str]) -> Tuple[str, ...]:
+    return tuple(dict.fromkeys(item_ids))
+
+
+@dataclass(frozen=True)
+class Pack:
+    """Metadata describing a logical grouping of context items."""
+
+    id: str
+    item_ids: Tuple[str, ...]
+    label: Optional[str] = None
+    metadata: Mapping[str, object] = field(default_factory=lambda: MappingProxyType({}))
+    summary: Optional[str] = None
+
+    def update(
+        self,
+        *,
+        item_ids: Optional[Sequence[str]] = None,
+        label: Optional[str] = None,
+        metadata: Optional[Mapping[str, object]] = None,
+        summary: Optional[str] = None,
+        id: Optional[str] = None,
+    ) -> "Pack":
+        updates: Dict[str, object] = {}
+        if id is not None:
+            updates["id"] = id
+        if item_ids is not None:
+            updates["item_ids"] = _normalise_ids(item_ids)
+        if label is not None:
+            updates["label"] = label
+        if metadata is not None:
+            merged = dict(self.metadata)
+            merged.update(metadata)
+            updates["metadata"] = _freeze_metadata(merged)
+        if summary is not None:
+            updates["summary"] = summary
+        return replace(self, **updates)
+
+
+class ContextPack(ContextRegistry):
+    """Context registry supporting logical pack groupings."""
+
+    def __init__(
+        self,
+        *,
+        id_prefix: str = "ctx",
+        pack_prefix: str = "pack",
+        items: Optional[Iterable[ContextItem]] = None,
+        packs: Optional[Iterable[Pack]] = None,
+    ) -> None:
+        super().__init__(id_prefix=id_prefix, items=items)
+        self._pack_prefix = pack_prefix
+        self._packs: Dict[str, Pack] = {}
+        self._next_pack_index = 1
+        if packs:
+            for pack in packs:
+                self._register_pack(pack)
+
+    def _register_pack(self, pack: Pack) -> None:
+        self._packs[pack.id] = pack
+        prefix = f"{self._pack_prefix}-"
+        if pack.id.startswith(prefix):
+            suffix = pack.id[len(prefix) :]
+            if suffix.isdigit():
+                self._next_pack_index = max(self._next_pack_index, int(suffix) + 1)
+
+    def _generate_pack_id(self) -> str:
+        generated = f"{self._pack_prefix}-{self._next_pack_index}"
+        self._next_pack_index += 1
+        return generated
+
+    # ------------------------------------------------------------------
+    def create_pack(
+        self,
+        item_ids: Sequence[str],
+        *,
+        label: Optional[str] = None,
+        metadata: Optional[Mapping[str, object]] = None,
+        summary: Optional[str] = None,
+        pack_id: Optional[str] = None,
+    ) -> Pack:
+        if pack_id is None:
+            pack_id = self._generate_pack_id()
+        elif pack_id in self._packs:
+            raise ValueError(f"Pack '{pack_id}' already exists")
+        normalised_ids = _normalise_ids(item_ids)
+        for item_id in normalised_ids:
+            if item_id not in self:
+                raise KeyError(f"Unknown context item '{item_id}'")
+        pack = Pack(
+            id=pack_id,
+            item_ids=normalised_ids,
+            label=label,
+            metadata=_freeze_metadata(metadata),
+            summary=summary,
+        )
+        self._register_pack(pack)
+        return pack
+
+    def remove_pack(self, pack_id: str) -> Pack:
+        return self._packs.pop(pack_id)
+
+    def packs_for_item(self, item_id: str) -> Tuple[Pack, ...]:
+        return tuple(pack for pack in self._packs.values() if item_id in pack.item_ids)
+
+    def get_pack(self, pack_id: str) -> Pack:
+        return self._packs[pack_id]
+
+    def iter_packs(self) -> Iterator[Pack]:
+        return iter(self._packs.values())
+
+    def extend_pack(self, pack_id: str, new_items: Sequence[str]) -> Pack:
+        pack = self.get_pack(pack_id)
+        updated_ids = _normalise_ids((*pack.item_ids, *new_items))
+        for item_id in updated_ids:
+            if item_id not in self:
+                raise KeyError(f"Unknown context item '{item_id}'")
+        updated = pack.update(item_ids=updated_ids)
+        self._packs[pack_id] = updated
+        return updated
+
+    def attach_summary(self, pack_id: str, summary: str) -> Pack:
+        updated = self.get_pack(pack_id).update(summary=summary)
+        self._packs[pack_id] = updated
+        return updated
+
+    def combine(self, other: ContextRegistry) -> None:
+        id_map = super().combine(other)
+        if not isinstance(other, ContextPack):
+            return
+        for pack in other.iter_packs():
+            new_id = pack.id
+            if new_id in self._packs:
+                new_id = self._generate_pack_id()
+            remapped_ids = [id_map.get(item_id, item_id) for item_id in pack.item_ids]
+            self._register_pack(pack.update(id=new_id, item_ids=remapped_ids))
+

--- a/src/agi/engine/summarizer.py
+++ b/src/agi/engine/summarizer.py
@@ -1,0 +1,173 @@
+"""Summarisation helpers built on the unified context data model."""
+
+from __future__ import annotations
+
+from collections import deque
+from textwrap import shorten
+from typing import Callable, Iterable, List, Optional, Sequence
+
+from .context_base import ContextItem, ContextRegistry, ContextView
+from .context_pack import ContextPack, Pack
+from .context_graph import ContextGraph
+
+__all__ = ["SummaryEngine", "RollingSummary"]
+
+
+class SummaryEngine:
+    """Derive textual summaries from :class:`ContextRegistry` data."""
+
+    def __init__(
+        self,
+        registry: ContextRegistry,
+        *,
+        reducer: Optional[Callable[[Sequence[str], int], str]] = None,
+    ) -> None:
+        self._registry = registry
+        self._reducer = reducer or self._default_reducer
+
+    # ------------------------------------------------------------------
+    @property
+    def registry(self) -> ContextRegistry:  # pragma: no cover - trivial accessor
+        return self._registry
+
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _normalise_text(text: str) -> str:
+        return " ".join(text.split())
+
+    @staticmethod
+    def _default_reducer(texts: Sequence[str], max_chars: int) -> str:
+        cleaned = [SummaryEngine._normalise_text(text) for text in texts if text and text.strip()]
+        if not cleaned:
+            return ""
+        if max_chars <= 0:
+            max_chars = 1
+        combined = " ".join(cleaned)
+        return shorten(combined, width=max_chars, placeholder="…")
+
+    def _ordered_items(
+        self,
+        item_ids: Optional[Sequence[str]],
+        *,
+        prefer_score: bool,
+    ) -> List[ContextItem]:
+        if item_ids is None:
+            items = list(self._registry.iter_items(reverse=True))
+        else:
+            items = [self._registry[item_id] for item_id in item_ids if item_id in self._registry]
+        key = (
+            (lambda item: (item.score, item.created_at))
+            if prefer_score
+            else (lambda item: item.created_at)
+        )
+        return sorted(items, key=key, reverse=True)
+
+    def summarize_items(
+        self,
+        item_ids: Optional[Sequence[str]] = None,
+        *,
+        max_items: int = 5,
+        prefer_score: bool = True,
+        max_chars: int = 480,
+    ) -> str:
+        ordered = self._ordered_items(item_ids, prefer_score=prefer_score)
+        texts = [item.text for item in ordered[:max_items]]
+        return self._reducer(texts, max_chars)
+
+    def summarize_view(
+        self,
+        view: ContextView,
+        *,
+        max_items: Optional[int] = None,
+        prefer_score: bool = True,
+        max_chars: int = 480,
+    ) -> str:
+        item_ids = view.item_ids
+        if max_items is None:
+            max_items = len(item_ids)
+        return self.summarize_items(item_ids, max_items=max_items, prefer_score=prefer_score, max_chars=max_chars)
+
+    def summarize_pack(
+        self,
+        pack: Pack,
+        *,
+        max_items: Optional[int] = None,
+        prefer_score: bool = True,
+        max_chars: int = 480,
+    ) -> str:
+        max_items = max_items or len(pack.item_ids)
+        return self.summarize_items(pack.item_ids, max_items=max_items, prefer_score=prefer_score, max_chars=max_chars)
+
+    def summarize_graph(
+        self,
+        graph: ContextGraph,
+        root_id: str,
+        *,
+        depth: Optional[int] = None,
+        direction: str = "forward",
+        include_root: bool = True,
+        max_items: int = 8,
+        prefer_score: bool = True,
+        max_chars: int = 480,
+    ) -> str:
+        item_ids = [item.id for item in graph.walk(root_id, depth=depth, direction=direction, include_start=include_root)]
+        return self.summarize_items(item_ids, max_items=max_items, prefer_score=prefer_score, max_chars=max_chars)
+
+    # Convenience wrappers -------------------------------------------------
+    def summarize_recent(self, *, max_items: int = 5, max_chars: int = 480) -> str:
+        return self.summarize_items(None, max_items=max_items, max_chars=max_chars)
+
+    def summarize_pack_id(
+        self,
+        pack_registry: ContextPack,
+        pack_id: str,
+        *,
+        max_items: Optional[int] = None,
+        prefer_score: bool = True,
+        max_chars: int = 480,
+    ) -> str:
+        pack = pack_registry.get_pack(pack_id)
+        return self.summarize_pack(pack, max_items=max_items, prefer_score=prefer_score, max_chars=max_chars)
+
+
+class RollingSummary:
+    """Maintain a rolling summary over a moving window of context items."""
+
+    def __init__(
+        self,
+        engine: SummaryEngine,
+        *,
+        history_size: int = 20,
+        max_items: int = 5,
+        max_chars: int = 480,
+    ) -> None:
+        self._engine = engine
+        self._history: deque[str] = deque(maxlen=history_size)
+        self._max_items = max_items
+        self._max_chars = max_chars
+        self._current: str = ""
+
+    @property
+    def summary(self) -> str:  # pragma: no cover - trivial accessor
+        return self._current
+
+    def push(self, item_id: str) -> str:
+        if item_id not in self._engine.registry:
+            raise KeyError(f"Unknown context item '{item_id}'")
+        self._history.append(item_id)
+        return self._recompute()
+
+    def extend(self, item_ids: Iterable[str]) -> str:
+        for item_id in item_ids:
+            self.push(item_id)
+        return self._current
+
+    def _recompute(self) -> str:
+        relevant = list(self._history)[-self._max_items :]
+        self._current = self._engine.summarize_items(
+            relevant,
+            max_items=self._max_items,
+            max_chars=self._max_chars,
+        )
+        return self._current
+


### PR DESCRIPTION
## Summary
- introduce a shared ContextRegistry/ContextItem core so graph, pack, and summarizer helpers operate on the same data model
- refactor ContextGraph and ContextPack to lean on the registry for lifecycle management while preserving relationship logic
- rebuild the summarizer facade, expose the engine package, and add focused unit tests that exercise the unified API

## Testing
- pytest python/tests/test_context_engine.py


------
https://chatgpt.com/codex/tasks/task_e_68c8858fc83883328bcd332603ee930f